### PR TITLE
add optional contact info and country tracking

### DIFF
--- a/src/features/wizard/hooks/useWebsiteWizard.ts
+++ b/src/features/wizard/hooks/useWebsiteWizard.ts
@@ -9,33 +9,38 @@ export const useWebsiteWizard = (totalSteps: number) => {
     websiteName,
     designType,
     pageContents,
-    email,
+    contactEmail,
+    contactPhone,
   } = useWizardStore();
 
   const canProceed = () => {
     switch (currentStep) {
       case 1:
         return websiteType !== null;
+
       case 2:
         return selectedPages.length > 0;
+
       case 3:
         return (
           websiteName.trim() !== "" &&
           (designType || "").trim() !== "" &&
-          (email || "").trim() !== ""
+          ((contactEmail && contactEmail.trim() !== "") ||
+            (contactPhone && contactPhone.trim() !== ""))
         );
+
       case 4:
         return selectedPages.every((page) => {
           const pageData = pageContents.find((pc) => pc.page === page);
           if (!pageData) return false;
 
-          // check if every section has either content or aiGenerated true
           return pageData.sections.every(
             (section) =>
               (section.content && section.content.trim() !== "") ||
               section.aiGenerated
           );
         });
+
       default:
         return false;
     }

--- a/src/features/wizard/store/wizardStore.ts
+++ b/src/features/wizard/store/wizardStore.ts
@@ -22,7 +22,9 @@ const defaultState: Omit<
   designType: "",
   primaryColor: "",
   secondaryColor: "",
-  email: "",
+  contactEmail: "",
+  contactPhone: "",
+  country: "",
   pageContents: [],
   websiteId: null,
 };

--- a/src/features/wizard/types/wizard.ts
+++ b/src/features/wizard/types/wizard.ts
@@ -11,9 +11,11 @@ export interface WizardState {
   designType: string;
   primaryColor: string;
   secondaryColor: string;
-  email: string;
+  contactEmail?: string;
+  contactPhone?: string;
+  country: string;
   pageContents: PageContent[];
-  websiteId: string | null; // <-- add this
+  websiteId: string | null;
 
   setWebsiteId: (id: string) => void;
   setCurrentStep: (step: number) => void;
@@ -26,9 +28,12 @@ export interface WizardState {
       designType: string;
       primaryColor: string;
       secondaryColor: string;
-      email: string;
+      contactEmail: string;
+      contactPhone: string;
+      country: string;
     }>
   ) => void;
+
   addSection: (page: PageType, section: Section) => void;
   updateSection: (
     page: PageType,

--- a/src/features/wizard/ui/StepThree.tsx
+++ b/src/features/wizard/ui/StepThree.tsx
@@ -12,28 +12,28 @@ import {
 } from "@/components/ui/select";
 import { useWizardStore } from "@/features/wizard/store/wizardStore";
 import { DESIGN_TYPES } from "../constants";
+import { useGeo } from "@/features/preview/domain/hooks/useGeoContext";
+import { useEffect } from "react";
 
 export function StepThree() {
+  const { country } = useGeo();
   const {
     websiteName,
     tagline,
-    email,
     designType,
     primaryColor,
     secondaryColor,
+    contactEmail,
+    contactPhone,
     setWebsiteInfo,
   } = useWizardStore();
 
+  useEffect(() => {
+    if (country) setWebsiteInfo({ country });
+  }, [country, setWebsiteInfo]);
+
   const handleChange = (field: string, value: string) => {
-    setWebsiteInfo({
-      websiteName,
-      tagline,
-      email,
-      designType,
-      primaryColor,
-      secondaryColor,
-      [field]: value,
-    });
+    setWebsiteInfo({ [field]: value });
   };
 
   return (
@@ -48,9 +48,8 @@ export function StepThree() {
 
       <Card className="p-6 max-w-2xl mx-auto">
         <div className="space-y-8">
-          {/* Top 2 / Bottom 2 */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-            {/* Top row */}
+            {/* Website name */}
             <div className="space-y-2">
               <Label htmlFor="websiteName">Website Name *</Label>
               <Input
@@ -61,6 +60,7 @@ export function StepThree() {
               />
             </div>
 
+            {/* Tagline */}
             <div className="space-y-2">
               <Label htmlFor="tagline">Tagline</Label>
               <Input
@@ -71,19 +71,32 @@ export function StepThree() {
               />
             </div>
 
-            {/* Bottom row */}
+            {/* Contact Email */}
             <div className="space-y-2">
-              <Label htmlFor="email">Contact Email *</Label>
+              <Label htmlFor="contactEmail">Email</Label>
               <Input
-                id="email"
+                id="contactEmail"
                 type="email"
                 placeholder="you@example.com"
-                value={email}
-                onChange={(e) => handleChange("email", e.target.value)}
+                value={contactEmail}
+                onChange={(e) => handleChange("contactEmail", e.target.value)}
               />
             </div>
 
+            {/* Contact Phone */}
             <div className="space-y-2">
+              <Label htmlFor="contactPhone">Phone</Label>
+              <Input
+                id="contactPhone"
+                type="tel"
+                placeholder="+975 17 123 456"
+                value={contactPhone}
+                onChange={(e) => handleChange("contactPhone", e.target.value)}
+              />
+            </div>
+
+            {/* Design type */}
+            <div className="space-y-2 sm:col-span-2">
               <Label htmlFor="designType">Design Type *</Label>
               <Select
                 value={designType}


### PR DESCRIPTION
## Description

This PR enhances the website creation wizard by making contact details optional and introducing automatic country detection.

## Changes 
- Added optional contact email and contact phone inputs (users can provide one, both, or neither)

- Stored geo-based country detection in wizard state

- Updated wizard validation to allow progression when at least one contact method is provided

- Refactored wizard store, hooks, and Step Three UI to support the new fields cleanly