### PR TITLE
Add page delete support in preview

### DIFF
--- a/src/features/preview/api/deletePage.ts
+++ b/src/features/preview/api/deletePage.ts
@@ -1,0 +1,35 @@
+export const deletePage = async (pageId: string) => {
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_BACKEND_URL}/pages/${pageId}`,
+      {
+        method: "DELETE",
+      },
+    );
+
+    if (!res.ok) {
+      const errorText = await res.text();
+
+      console.error("❌ Backend API Error:", errorText);
+
+      return {
+        success: false,
+        error: `Backend returned ${res.status}: ${errorText}`,
+      };
+    }
+
+    const data = await res.json();
+
+    return {
+      success: true,
+      data,
+    };
+  } catch (err) {
+    console.error("🔥 Network or parsing error:", err);
+
+    return {
+      success: false,
+      error: "Network error or invalid response from server",
+    };
+  }
+};

--- a/src/features/preview/hooks/useDeletePage.ts
+++ b/src/features/preview/hooks/useDeletePage.ts
@@ -1,0 +1,19 @@
+import { deletePage } from "@/features/preview/api/deletePage";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const useDeletePage = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ pageId }: { pageId: string; websiteId: string }) =>
+      deletePage(pageId),
+
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["website", variables.websiteId],
+      });
+    },
+  });
+};
+
+export default useDeletePage;

--- a/src/features/preview/ui/PreviewPanelJson.tsx
+++ b/src/features/preview/ui/PreviewPanelJson.tsx
@@ -14,6 +14,7 @@ import {
   LayoutDashboard,
   ChevronDown,
   MoveUpRight,
+  Trash2,
 } from "lucide-react";
 import {
   AlertDialog,
@@ -43,6 +44,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useGeneratePreviewWebsite } from "../hooks/useGeneratePreviewWebsite";
+import useDeletePage from "../hooks/useDeletePage";
 
 type DeviceType = "desktop" | "tablet" | "mobile";
 
@@ -64,6 +66,33 @@ interface PreviewPanelJsonProps {
   currentPageId: string;
 }
 
+const FIXED_MAIN_PAGE_SLUGS = [
+  "index",
+  "home",
+  "about",
+  "contact",
+  "services",
+  "tours",
+  "rooms",
+  "amenities",
+  "location",
+  "menu",
+  "projects",
+  "products",
+];
+
+const canDeletePage = (pageSlug: string) => {
+  const normalizedSlug = pageSlug.toLowerCase();
+
+  const isSubPage = normalizedSlug.includes("/");
+
+  if (isSubPage) {
+    return true;
+  }
+
+  return !FIXED_MAIN_PAGE_SLUGS.includes(normalizedSlug);
+};
+
 export function PreviewPanelJson({
   websiteId,
   websiteData,
@@ -83,6 +112,8 @@ export function PreviewPanelJson({
   const isDeployed = deploymentCount > 0;
   const { mutate: generatePreview, isPending: isGeneratingPreview } =
     useGeneratePreviewWebsite();
+  const { mutate: deletePageMutation, isPending: isDeletingPage } =
+    useDeletePage();
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   useEffect(() => {
     const width = window.innerWidth;
@@ -174,6 +205,53 @@ export function PreviewPanelJson({
     });
   };
 
+  const handleDeletePage = (pageId: string) => {
+    const pageToDelete = sortedPages.find((page) => page.page_id === pageId);
+
+    const parentPageSlug = pageToDelete?.page.includes("/")
+      ? pageToDelete.page.split("/")[0]
+      : null;
+
+    const parentPage = parentPageSlug
+      ? sortedPages.find((page) => page.page === parentPageSlug)
+      : null;
+
+    deletePageMutation(
+      {
+        pageId,
+        websiteId,
+      },
+      {
+        onSuccess: (res) => {
+          if (!res.success) {
+            toast.error(res.error || "Failed to delete page");
+            return;
+          }
+
+          toast.success("Page deleted successfully");
+
+          if (currentPageId === pageId) {
+            if (parentPage) {
+              onPageChange(parentPage.page_id);
+              return;
+            }
+
+            const fallbackPage = sortedPages.find(
+              (page) => page.page_id !== pageId,
+            );
+
+            if (fallbackPage) {
+              onPageChange(fallbackPage.page_id);
+            }
+          }
+        },
+
+        onError: () => {
+          toast.error("Failed to delete page");
+        },
+      },
+    );
+  };
   return (
     <div className="flex h-screen flex-col bg-muted">
       {/* Header */}
@@ -330,17 +408,111 @@ export function PreviewPanelJson({
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="start" className="w-60">
                       <DropdownMenuItem
-                        onClick={() => onPageChange(mainPage.page_id)}
+                        onSelect={(e) => e.preventDefault()}
+                        className="flex items-center justify-between gap-2"
                       >
-                        {mainPage.title} (Overview)
+                        <button
+                          type="button"
+                          onClick={() => onPageChange(mainPage.page_id)}
+                          className="flex-1 text-left"
+                        >
+                          {mainPage.title} (Overview)
+                        </button>
+
+                        {canDeletePage(mainPage.page) && (
+                          <AlertDialog>
+                            <AlertDialogTrigger asChild>
+                              <button
+                                type="button"
+                                disabled={isDeletingPage}
+                                className="rounded-sm p-1 text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <Trash2 className="h-3.5 w-3.5" />
+                              </button>
+                            </AlertDialogTrigger>
+
+                            <AlertDialogContent>
+                              <AlertDialogHeader>
+                                <AlertDialogTitle>
+                                  Delete this page?
+                                </AlertDialogTitle>
+                                <AlertDialogDescription>
+                                  This page will be removed from your website
+                                  preview.
+                                </AlertDialogDescription>
+                              </AlertDialogHeader>
+
+                              <AlertDialogFooter>
+                                <AlertDialogCancel>Cancel</AlertDialogCancel>
+
+                                <AlertDialogAction
+                                  onClick={() =>
+                                    handleDeletePage(mainPage.page_id)
+                                  }
+                                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                                >
+                                  Delete Page
+                                </AlertDialogAction>
+                              </AlertDialogFooter>
+                            </AlertDialogContent>
+                          </AlertDialog>
+                        )}
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       {subPages.map((sub) => (
                         <DropdownMenuItem
-                          key={sub.page_id} // Use page_id for keys
-                          onClick={() => onPageChange(sub.page_id)}
+                          key={sub.page_id}
+                          onSelect={(e) => e.preventDefault()}
+                          className="flex items-center justify-between gap-2"
                         >
-                          {sub.title}
+                          <button
+                            type="button"
+                            onClick={() => onPageChange(sub.page_id)}
+                            className="flex-1 text-left"
+                          >
+                            {sub.title}
+                          </button>
+
+                          {canDeletePage(sub.page) && (
+                            <AlertDialog>
+                              <AlertDialogTrigger asChild>
+                                <button
+                                  type="button"
+                                  disabled={isDeletingPage}
+                                  className="rounded-sm p-1 text-destructive hover:bg-destructive/10 disabled:opacity-50"
+                                  onClick={(e) => e.stopPropagation()}
+                                >
+                                  <Trash2 className="h-3.5 w-3.5" />
+                                </button>
+                              </AlertDialogTrigger>
+
+                              <AlertDialogContent>
+                                <AlertDialogHeader>
+                                  <AlertDialogTitle>
+                                    Delete this subpage?
+                                  </AlertDialogTitle>
+                                  <AlertDialogDescription>
+                                    This subpage will be removed from your
+                                    website preview.
+                                  </AlertDialogDescription>
+                                </AlertDialogHeader>
+
+                                <AlertDialogFooter>
+                                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+
+                                  <AlertDialogAction
+                                    onClick={() =>
+                                      handleDeletePage(sub.page_id)
+                                    }
+                                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                                  >
+                                    Delete Page
+                                  </AlertDialogAction>
+                                </AlertDialogFooter>
+                              </AlertDialogContent>
+                            </AlertDialog>
+                          )}
                         </DropdownMenuItem>
                       ))}
                     </DropdownMenuContent>
@@ -350,18 +522,53 @@ export function PreviewPanelJson({
 
               // RENDER SIMPLE BUTTON (For Home, About, Contact, etc.)
               return (
-                <Button
-                  key={mainPage.page_id}
-                  size="sm"
-                  variant={
-                    currentPageId === mainPage.page_id ? "default" : "outline"
-                  }
-                  onClick={() => onPageChange(mainPage.page_id)}
-                >
-                  {/* Icon is now rendered for every simple button */}
-                  <FileText className="h-3 w-3 mr-1" />
-                  {mainPage.title}
-                </Button>
+                <div key={mainPage.page_id} className="flex items-center gap-1">
+                  <Button
+                    size="sm"
+                    variant={
+                      currentPageId === mainPage.page_id ? "default" : "outline"
+                    }
+                    onClick={() => onPageChange(mainPage.page_id)}
+                  >
+                    <FileText className="h-3 w-3 mr-1" />
+                    {mainPage.title}
+                  </Button>
+
+                  {canDeletePage(mainPage.page) && (
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button
+                          size="icon"
+                          variant="outline"
+                          disabled={isDeletingPage}
+                          className="h-8 w-8 text-destructive"
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </Button>
+                      </AlertDialogTrigger>
+
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Delete this page?</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This page will be removed from your website preview.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+
+                          <AlertDialogAction
+                            onClick={() => handleDeletePage(mainPage.page_id)}
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                          >
+                            Delete Page
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  )}
+                </div>
               );
             })}
           </div>


### PR DESCRIPTION
## Description
This PR adds page deletion support from the website preview panel. Users can now delete generated pages directly from the page selector while keeping the default/fixed website pages protected.
The delete action is available for user-generated main pages and all subpages. Fixed pages such as Home, About, Contact, Services, Tours, Rooms, Amenities, Location, Menu, Projects, and Products cannot be deleted.

## Changes Made
- Added `deletePage` API function for deleting pages from the backend
- Added `useDeletePage` mutation hook using React Query
- Added delete controls to the preview page selector
- Added confirmation dialog before deleting a page
- Added logic to prevent fixed/default main pages from being deleted
- Allowed user-generated main pages to be deleted
- Allowed all subpages to be deleted from dropdown menus
- Redirected users to the parent page after deleting a subpage
- Redirected users to a fallback page after deleting the current main page
- Added success and error toast messages for delete actions

