### PR TITLE
add real estate website type to wizard

### DIFF
--- a/src/features/preview/ui/PreviewPanelJson.tsx
+++ b/src/features/preview/ui/PreviewPanelJson.tsx
@@ -79,6 +79,8 @@ const FIXED_MAIN_PAGE_SLUGS = [
   "menu",
   "projects",
   "products",
+  "properties",
+  "agents",
 ];
 
 const canDeletePage = (pageSlug: string) => {

--- a/src/features/wizard/constants/pages.ts
+++ b/src/features/wizard/constants/pages.ts
@@ -108,6 +108,20 @@ export const pageOptions: PageOption[] = [
     description: "How we work",
     icon: Clock,
   },
+
+  // Real Estate
+  {
+    type: "properties",
+    label: "Properties",
+    description: "Real estate listings",
+    icon: Home,
+  },
+  {
+    type: "agents",
+    label: "Agents",
+    description: "Meet our agents",
+    icon: Users,
+  },
 ];
 
 /**
@@ -124,7 +138,8 @@ export const websitePagesMap: Record<
   | "hotel"
   | "travel agency"
   | "shop"
-  | "smallMediumBusiness",
+  | "smallMediumBusiness"
+  | "real estate",
   PageType[]
 > = {
   portfolio: ["home", "about", "projects", "services", "contact"],
@@ -138,6 +153,15 @@ export const websitePagesMap: Record<
   shop: ["home", "products", "about", "contact"],
 
   smallMediumBusiness: ["home", "services", "about", "products", "contact"],
+
+  "real estate": [
+    "home",
+    "services",
+    "about",
+    "contact",
+    "properties",
+    "agents",
+  ],
 };
 
 export const websitePageDefaults: Record<
@@ -176,6 +200,11 @@ export const websitePageDefaults: Record<
     required: ["home"],
     defaultSelected: ["services", "about", "contact"],
   },
+
+  "real estate": {
+    required: ["home"],
+    defaultSelected: ["services", "about", "contact", "properties"],
+  },
 };
 
 /**
@@ -211,6 +240,10 @@ export const pageSectionsMap: Record<PageType, SectionType[]> = {
 
   // Service Pages
   process: ["content"], // workflow + description
+
+  // Real Estate
+  properties: ["content"], // property listings + highlights + CTA
+  agents: ["content"], // agent bios + highlights + CTA
 };
 
 export const defaultPagePlaceholders: Record<PageType, Omit<Section, "id">[]> =
@@ -338,6 +371,24 @@ export const defaultPagePlaceholders: Record<PageType, Omit<Section, "id">[]> =
         content: "",
         placeholder:
           "🧩 Explain your workflow or process. Walk visitors through how you deliver your product or service.",
+      },
+    ],
+
+    properties: [
+      {
+        type: "content",
+        content: "",
+        placeholder:
+          "🏡 Showcase your property listings. Describe key features, location benefits, and what makes them special.",
+      },
+    ],
+
+    agents: [
+      {
+        type: "content",
+        content: "",
+        placeholder:
+          "👤 Introduce your real estate agents. Highlight their expertise, experience, and how they can help clients.",
       },
     ],
   };

--- a/src/features/wizard/constants/website-types.ts
+++ b/src/features/wizard/constants/website-types.ts
@@ -1,5 +1,5 @@
 import { WebsiteType } from "../types";
-import { Briefcase, Home, Globe, Coffee, Building } from "lucide-react";
+import { Briefcase, Home, Globe, Coffee, Building, Store } from "lucide-react";
 
 export const websiteTypes = [
   {
@@ -30,7 +30,13 @@ export const websiteTypes = [
     type: "smallMediumBusiness" as WebsiteType,
     label: "Small & Medium Business",
     description:
-      "Create a website designed for small and medium-sized businesses",
+      "Create a website for (shops, local businesses, or service-based brands)",
+    icon: Store,
+  },
+  {
+    type: "real estate" as WebsiteType,
+    label: "Real Estate",
+    description: "Showcase property listings and real estate services",
     icon: Building,
   },
 ];

--- a/src/features/wizard/types/page.ts
+++ b/src/features/wizard/types/page.ts
@@ -14,8 +14,9 @@ export type PageType =
   | "amenities"
   | "location"
   | "tours"
-  | "process";
-
+  | "process"
+  | "properties"
+  | "agents";
 export interface PageContent {
   page: PageType;
   sections: Section[];

--- a/src/features/wizard/types/website.ts
+++ b/src/features/wizard/types/website.ts
@@ -5,7 +5,8 @@ export type WebsiteType =
   | "restaurant"
   | "hotel"
   | "travel agency"
-  | "smallMediumBusiness";
+  | "smallMediumBusiness"
+  | "real estate";
 
 export type WizardStateForAPI = {
   websiteName: string;


### PR DESCRIPTION
## Description
Added Real Estate website type in the website creation wizard.

## Changes Made
- Added Real Estate as a selectable website type
- Added Real Estate-specific pages to the wizard flow
- Updated website/page type definitions to support Real Estate
- Changed website type icon/label/description for better UX