### PR TITLE
Refactor preview JSON renderer into modular renderers

### DIFF
--- a/src/features/preview/hooks/useRendererActions.ts
+++ b/src/features/preview/hooks/useRendererActions.ts
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCallback } from "react";
+
+import type { WebElement } from "@/features/preview/types";
+import type { ComponentKey } from "@/features/preview/ui/renderer/shared/rendererTypes";
+
+interface UseRendererActionsParams {
+  onUpdateElement?: (id: number, updates: Partial<WebElement>) => void;
+  onUpdateSharedElement?: (
+    componentKey: ComponentKey,
+    elementId: number,
+    updates: Partial<WebElement>,
+  ) => void;
+  uploadImage: (params: {
+    file: File;
+    elementId: number;
+    onUploaded: (content: string) => void;
+  }) => Promise<void>;
+}
+
+export function useRendererActions({
+  onUpdateElement,
+  onUpdateSharedElement,
+  uploadImage,
+}: UseRendererActionsParams) {
+  const handleTextSave = useCallback(
+    (
+      id: number,
+      componentKey: ComponentKey | undefined,
+      newContent: string,
+    ) => {
+      if (newContent.trim() === "") {
+        return;
+      }
+
+      if (componentKey && onUpdateSharedElement) {
+        onUpdateSharedElement(componentKey, id, {
+          content: newContent,
+        });
+        return;
+      }
+
+      onUpdateElement?.(id, {
+        content: newContent,
+      });
+    },
+    [onUpdateElement, onUpdateSharedElement],
+  );
+
+  const updateImageContent = useCallback(
+    (id: number, componentKey?: ComponentKey) => {
+      return (content: string) => {
+        if (componentKey) {
+          onUpdateSharedElement?.(componentKey, id, {
+            content,
+          });
+          return;
+        }
+
+        onUpdateElement?.(id, {
+          content,
+        });
+      };
+    },
+    [onUpdateElement, onUpdateSharedElement],
+  );
+
+  const handleImageChange = useCallback(
+    async (
+      event: React.ChangeEvent<HTMLInputElement>,
+      id: number,
+      componentKey?: ComponentKey,
+    ) => {
+      const file = event.target.files?.[0];
+
+      if (!file) {
+        return;
+      }
+
+      await uploadImage({
+        file,
+        elementId: id,
+        onUploaded: updateImageContent(id, componentKey),
+      });
+
+      event.target.value = "";
+    },
+    [uploadImage, updateImageContent],
+  );
+
+  return {
+    handleTextSave,
+    handleImageChange,
+  };
+}

--- a/src/features/preview/stores/useRendererStore.ts
+++ b/src/features/preview/stores/useRendererStore.ts
@@ -1,0 +1,21 @@
+import { create } from "zustand";
+
+interface RendererState {
+  hoveredImageId: number | null;
+  activeImageId: number | null;
+  isEditingText: boolean;
+
+  setHoveredImageId: (id: number | null) => void;
+  setActiveImageId: (id: number | null) => void;
+  setIsEditingText: (isEditing: boolean) => void;
+}
+
+export const useRendererStore = create<RendererState>((set) => ({
+  hoveredImageId: null,
+  activeImageId: null,
+  isEditingText: false,
+
+  setHoveredImageId: (id) => set({ hoveredImageId: id }),
+  setActiveImageId: (id) => set({ activeImageId: id }),
+  setIsEditingText: (isEditing) => set({ isEditingText: isEditing }),
+}));

--- a/src/features/preview/ui/JsonRenderer.tsx
+++ b/src/features/preview/ui/JsonRenderer.tsx
@@ -1,31 +1,40 @@
 "use client";
 
-import type React from "react";
-import { createElement, type ReactElement, useRef, useState } from "react";
+import { useCallback, useRef } from "react";
 
 import type { SharedComponents, WebElement } from "@/features/preview/types";
 import { usePreviewImageUpload } from "@/features/preview/hooks/usePreviewImageUpload";
-import { normalizeAttributes } from "@/features/preview/utils/rendererAttributes";
-import { findCarouselSlides } from "@/features/preview/utils/rendererElements";
-import {
-  cssStringToObject,
-  hasExplicitSize,
-} from "@/features/preview/utils/rendererStyles";
+import { useRendererActions } from "@/features/preview/hooks/useRendererActions";
+import { useRendererStore } from "@/features/preview/stores/useRendererStore";
 import { useSession } from "@/shared/session";
-import { cn } from "@/lib/utils";
 
-import { CarouselRenderer } from "./interactiveComponents/CarouselRenderer";
-import { FloatingWhatsApp } from "./interactiveComponents/FloatingWhatsApp";
+import { FloatingWhatsApp } from "@/features/preview/ui/interactiveComponents/FloatingWhatsApp";
+import { CarouselElementRenderer } from "@/features/preview/ui/renderer/carousel/CarouselElementRenderer";
+import { CarouselSlideRenderer } from "@/features/preview/ui/renderer/carousel/CarouselSlideRenderer";
+import { DefaultElementRenderer } from "@/features/preview/ui/renderer/DefaultElementRenderer";
+import { applyEditableTextProps } from "@/features/preview/ui/renderer/shared/editableTextProps";
+import { createElementProps } from "@/features/preview/ui/renderer/shared/createElementProps";
+import {
+  getElementKey,
+  getElementKind,
+} from "@/features/preview/ui/renderer/shared/rendererElementUtils";
+import type {
+  ComponentKey,
+  DeviceType,
+} from "@/features/preview/ui/renderer/shared/rendererTypes";
+import { ImageElementRenderer } from "@/features/preview/ui/renderer/image/ImageElementRenderer";
+import { HeroSectionRenderer } from "@/features/preview/ui/renderer/sections/HeroSectionRenderer";
+import { OverlaySectionRenderer } from "@/features/preview/ui/renderer/sections/OverlaySectionRenderer";
 
 interface JsonRendererProps {
   elements: WebElement[];
   sharedComponents?: SharedComponents;
-  device?: "desktop" | "tablet" | "mobile";
+  device?: DeviceType;
   onUpdateElement?: (id: number, updates: Partial<WebElement>) => void;
   contactPhone?: string;
   floatingWhatsappEnabled?: boolean;
   onUpdateSharedElement?: (
-    componentKey: "navbar" | "footer",
+    componentKey: ComponentKey,
     elementId: number,
     updates: Partial<WebElement>,
   ) => void;
@@ -42,537 +51,138 @@ export function JsonRenderer({
 }: JsonRendererProps) {
   const { user } = useSession();
 
-  const [hoveredImageId, setHoveredImageId] = useState<number | null>(null);
-  const [activeImageId, setActiveImageId] = useState<number | null>(null);
-  const [isEditingText, setIsEditingText] = useState(false);
-
   const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  const isEditingText = useRendererStore((state) => state.isEditingText);
+  const activeImageId = useRendererStore((state) => state.activeImageId);
+  const setIsEditingText = useRendererStore((state) => state.setIsEditingText);
 
   const { uploadingImageId, uploadImage } = usePreviewImageUpload({
     userId: user?.id,
   });
 
+  const { handleTextSave, handleImageChange } = useRendererActions({
+    onUpdateElement,
+    onUpdateSharedElement,
+    uploadImage,
+  });
+
   const isPaused =
     isEditingText || uploadingImageId !== null || activeImageId !== null;
 
-  const handleTextSave = (
-    id: number,
-    componentKey: "navbar" | "footer" | undefined,
-    newContent: string,
-  ) => {
-    if (newContent.trim() === "") return;
+  const canEdit = Boolean(onUpdateElement || onUpdateSharedElement);
 
-    if (componentKey && onUpdateSharedElement) {
-      onUpdateSharedElement(componentKey, id, {
-        content: newContent,
+  const renderElement = useCallback(
+    (element: WebElement, componentKey?: ComponentKey): React.ReactElement => {
+      const elementKey = getElementKey(element, device);
+      const elementKind = getElementKind(element);
+
+      let props = createElementProps({
+        element,
+        device,
       });
-      return;
-    }
 
-    if (onUpdateElement) {
-      onUpdateElement(id, {
-        content: newContent,
+      if (element.tag === "a") {
+        props.href = undefined;
+        props.onClick = undefined;
+      }
+
+      props = applyEditableTextProps({
+        props,
+        element,
+        componentKey,
+        canEdit,
+        onTextSave: handleTextSave,
+        setIsEditingText,
       });
-    }
-  };
 
-  const handleImageChange = async (
-    event: React.ChangeEvent<HTMLInputElement>,
-    id: number,
-    componentKey?: "navbar" | "footer",
-  ) => {
-    const file = event.target.files?.[0];
-
-    if (!file) return;
-
-    const updater = componentKey
-      ? (content: string) =>
-          onUpdateSharedElement?.(componentKey, id, { content })
-      : (content: string) => onUpdateElement?.(id, { content });
-
-    await uploadImage({
-      file,
-      elementId: id,
-      onUploaded: updater,
-    });
-
-    event.target.value = "";
-  };
-
-  const renderElement = (
-    element: WebElement,
-    componentKey?: "navbar" | "footer",
-  ): ReactElement => {
-    const {
-      id,
-      tag,
-      class: className,
-      content,
-      children,
-      attributes,
-    } = element;
-
-    const props: React.AllHTMLAttributes<HTMLElement> & { key: React.Key } = {
-      key: `${id}-${device}`,
-      className,
-      ...normalizeAttributes(attributes),
-      style: {
-        ...cssStringToObject(attributes?.style),
-      },
-    };
-
-    const componentType = element.attributes?.["data-component"];
-
-    if (componentType === "carousel") {
-      const autoplay = String(element.attributes?.["data-autoplay"]) === "true";
-      const intervalAttr = element.attributes?.["data-interval"];
-      const interval = intervalAttr ? Number(intervalAttr) : undefined;
-      const slides = findCarouselSlides(children);
-
-      return (
-        <CarouselRenderer
-          key={id}
-          className={className}
-          slides={slides}
-          autoplay={autoplay}
-          interval={interval}
-          isPaused={isPaused}
-          renderElement={(el) => renderElement(el, componentKey)}
-        />
-      );
-    }
-
-    const isLink = tag === "a";
-
-    if (isLink) {
-      props.href = undefined;
-      props.onClick = undefined;
-    }
-
-    const hasNoChildren = !children || children.length === 0;
-
-    const isTextElement =
-      typeof content === "string" && hasNoChildren && tag !== "img";
-
-    const isEditable =
-      isTextElement && (!!onUpdateElement || !!onUpdateSharedElement);
-
-    if (isEditable) {
-      props.contentEditable = true;
-      props.suppressContentEditableWarning = true;
-
-      if (["h1", "h2", "p"].includes(tag)) {
-        (
-          props as unknown as React.HTMLAttributes<HTMLElement> &
-            Record<string, unknown>
-        )["data-tour"] = "editable-text";
-      }
-
-      props.style = {
-        ...(props.style || {}),
-        cursor: "text",
-        transition: "all 0.15s ease",
-      };
-
-      props.onFocus = (event) => {
-        setIsEditingText(true);
-        event.currentTarget.style.outline = "2px solid #facc15";
-      };
-
-      props.onBlur = (event) => {
-        setIsEditingText(false);
-        event.currentTarget.style.outline = "none";
-        handleTextSave(id, componentKey, event.currentTarget.innerText);
-      };
-
-      props.onMouseEnter = (event) => {
-        event.currentTarget.style.outline = "2px dashed rgba(250,204,21,0.7)";
-      };
-
-      props.onMouseLeave = (event) => {
-        if (document.activeElement !== event.currentTarget) {
-          event.currentTarget.style.outline = "none";
-        }
-      };
-
-      props.onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
-        if (event.key === "Enter" && !event.shiftKey) {
-          event.preventDefault();
-          event.currentTarget.blur();
-        }
-      };
-    }
-
-    const isCarouselSlide =
-      element.attributes?.["data-role"] === "carousel-slide";
-
-    if (isCarouselSlide) {
-      return (
-        <div key={id} className={cn("w-full h-full", className)}>
-          {children?.map((child) => renderElement(child, componentKey))}
-
-          <button
-            onClick={(event) => {
-              event.stopPropagation();
-
-              const bgImage = children?.find(
-                (child) =>
-                  child.tag === "img" &&
-                  child.attributes?.["data-role"] === "carousel-bg",
-              );
-
-              if (bgImage) {
-                if (activeImageId !== bgImage.id) {
-                  setActiveImageId(bgImage.id);
-                }
-
-                fileInputRefs.current[String(id)]?.click();
-              }
-            }}
-            className="absolute top-4 right-4 z-50 bg-yellow-400 text-black px-4 py-2 rounded-md shadow-lg text-sm font-semibold"
-          >
-            Change
-          </button>
-
-          <input
-            ref={(element) => {
-              fileInputRefs.current[String(id)] = element;
-            }}
-            type="file"
-            accept="image/*"
-            className="hidden"
-            onChange={(event) => {
-              const bgImage = children?.find(
-                (child) =>
-                  child.tag === "img" &&
-                  child.attributes?.["data-role"] === "carousel-bg",
-              );
-
-              if (bgImage) {
-                handleImageChange(event, bgImage.id, componentKey);
-                setActiveImageId(null);
-              }
-            }}
-          />
-        </div>
-      );
-    }
-
-    const isOverLaySection =
-      element.attributes?.["data-component"] === "overlay-section";
-
-    if (isOverLaySection) {
-      const bgImage = children?.find(
-        (child) =>
-          child.tag === "img" &&
-          child.attributes?.["data-role"] === "overlay-bg",
-      );
-
-      const isUploading = bgImage && uploadingImageId === bgImage.id;
-
-      return (
-        <section key={id} className={cn("relative", className)}>
-          {bgImage && renderElement(bgImage, componentKey)}
-
-          {isUploading && (
-            <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/40 text-white">
-              <div className="flex flex-col items-center gap-2">
-                <div className="h-6 w-6 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                <span className="text-sm">Uploading...</span>
-              </div>
-            </div>
-          )}
-
-          <>
-            {children
-              ?.filter((child) => child !== bgImage)
-              .map((child) => renderElement(child, componentKey))}
-          </>
-
-          {bgImage && (
-            <>
-              <button
-                onClick={(event) => {
-                  event.stopPropagation();
-
-                  if (!isUploading) {
-                    fileInputRefs.current[`overlay-${id}`]?.click();
-                  }
-                }}
-                className="absolute top-2 right-2 z-50 bg-yellow-400 text-black px-3 py-1.5 rounded-md shadow-md text-xs font-semibold"
-              >
-                {isUploading ? "Uploading..." : "Change Background"}
-              </button>
-
-              <input
-                ref={(element) => {
-                  fileInputRefs.current[`overlay-${id}`] = element;
-                }}
-                type="file"
-                accept="image/*"
-                className="hidden"
-                disabled={Boolean(isUploading)}
-                onChange={(event) => {
-                  handleImageChange(event, bgImage.id, componentKey);
-                }}
-              />
-            </>
-          )}
-        </section>
-      );
-    }
-
-    const isHeroSection =
-      element.attributes?.["data-component"] === "hero-section";
-
-    if (isHeroSection) {
-      const bgImage = children?.find(
-        (child) =>
-          child.tag === "img" &&
-          child.attributes?.["data-role"] === "carousel-bg",
-      );
-
-      const isUploading = bgImage && uploadingImageId === bgImage.id;
-
-      return (
-        <section key={id} className={cn("relative", className)}>
-          {bgImage && renderElement(bgImage, componentKey)}
-
-          {isUploading && (
-            <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/40 text-white">
-              <div className="flex flex-col items-center gap-2">
-                <div className="h-6 w-6 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                <span className="text-sm">Uploading...</span>
-              </div>
-            </div>
-          )}
-
-          <>
-            {children
-              ?.filter((child) => child !== bgImage)
-              .map((child) => renderElement(child, componentKey))}
-          </>
-
-          <button
-            data-tour="hero-background"
-            onClick={(event) => {
-              event.stopPropagation();
-
-              if (!isUploading) {
-                fileInputRefs.current[`hero-${id}`]?.click();
-              }
-            }}
-            className="absolute top-2 right-2 z-50 bg-yellow-400 text-black px-3 py-1.5 rounded-md shadow-md text-xs font-semibold"
-          >
-            {isUploading ? "Uploading..." : "Change Background"}
-          </button>
-
-          <input
-            ref={(element) => {
-              fileInputRefs.current[`hero-${id}`] = element;
-            }}
-            type="file"
-            accept="image/*"
-            className="hidden"
-            disabled={Boolean(isUploading)}
-            onChange={(event) => {
-              if (bgImage) {
-                handleImageChange(event, bgImage.id, componentKey);
-              }
-            }}
-          />
-        </section>
-      );
-    }
-
-    if (tag === "img") {
-      const imageSrc = content?.startsWith("http") ? content : attributes?.src;
-      const fixedStyle = cssStringToObject(attributes?.style);
-
-      const isBackgroundImage =
-        element.attributes?.["data-role"] === "carousel-bg" ||
-        element.attributes?.["data-role"] === "overlay-bg";
-
-      let role = element.attributes?.["data-role"];
-
-      if (!role) {
-        if (
-          className?.includes("h-[") ||
-          className?.includes("h-full") ||
-          className?.includes("object-cover") ||
-          className?.includes("absolute")
-        ) {
-          role = "cover";
-        } else {
-          role = "contain";
-        }
-      }
-
-      const isLogo = role === "logo";
-      const isIcon = role === "social-icon";
-      const isAvatar =
-        className?.includes("rounded-full") && className?.match(/\bw-\d+/);
-
-      hasExplicitSize(className);
-
-      const isActive =
-        device === "desktop" ? hoveredImageId === id : activeImageId === id;
-
-      if (isBackgroundImage) {
-        return (
-          <div
-            key={id}
-            className="absolute inset-0"
-            onMouseEnter={() => device === "desktop" && setHoveredImageId(id)}
-            onMouseLeave={() => device === "desktop" && setHoveredImageId(null)}
-          >
-            <img
-              src={imageSrc}
-              className="absolute inset-0 w-full h-full object-cover"
-              style={{ zIndex: 0 }}
-              alt=""
+      switch (elementKind) {
+        case "carousel":
+          return (
+            <CarouselElementRenderer
+              key={elementKey}
+              element={element}
+              componentKey={componentKey}
+              isPaused={isPaused}
+              renderElement={renderElement}
             />
+          );
 
-            <button
-              onClick={(event) => {
-                event.stopPropagation();
-
-                if (!uploadingImageId) {
-                  fileInputRefs.current[String(id)]?.click();
-                }
-              }}
-              className="absolute top-2 right-2 z-50 bg-yellow-400 text-black px-3 py-1.5 rounded-md shadow-md text-xs font-semibold"
-            >
-              {uploadingImageId === id ? "Uploading..." : "Change"}
-            </button>
-
-            <input
-              ref={(element) => {
-                fileInputRefs.current[String(id)] = element;
-              }}
-              type="file"
-              accept="image/*"
-              className="hidden"
-              disabled={uploadingImageId === id}
-              onChange={(event) => handleImageChange(event, id, componentKey)}
+        case "carousel-slide":
+          return (
+            <CarouselSlideRenderer
+              key={elementKey}
+              element={element}
+              componentKey={componentKey}
+              renderElement={renderElement}
+              fileInputRefs={fileInputRefs}
+              uploadingImageId={uploadingImageId}
+              onImageChange={handleImageChange}
             />
-          </div>
-        );
+          );
+
+        case "overlay-section":
+          return (
+            <OverlaySectionRenderer
+              key={elementKey}
+              element={element}
+              componentKey={componentKey}
+              renderElement={renderElement}
+              fileInputRefs={fileInputRefs}
+              uploadingImageId={uploadingImageId}
+              onImageChange={handleImageChange}
+            />
+          );
+
+        case "hero-section":
+          return (
+            <HeroSectionRenderer
+              key={elementKey}
+              element={element}
+              componentKey={componentKey}
+              renderElement={renderElement}
+              fileInputRefs={fileInputRefs}
+              uploadingImageId={uploadingImageId}
+              onImageChange={handleImageChange}
+            />
+          );
+
+        case "image":
+          return (
+            <ImageElementRenderer
+              key={elementKey}
+              element={element}
+              props={props}
+              device={device}
+              componentKey={componentKey}
+              fileInputRefs={fileInputRefs}
+              uploadingImageId={uploadingImageId}
+              onImageChange={handleImageChange}
+            />
+          );
+
+        default:
+          return (
+            <DefaultElementRenderer
+              key={elementKey}
+              element={element}
+              props={props}
+              componentKey={componentKey}
+              renderElement={renderElement}
+            />
+          );
       }
-
-      return (
-        <div
-          key={id}
-          data-tour={isLogo ? "site-logo" : undefined}
-          className={cn(
-            "relative  leading-none",
-            isIcon ? "inline-block" : "block",
-            isIcon || isAvatar ? null : "w-full",
-            isLogo ? "h-full" : "h-auto",
-          )}
-          style={{
-            zIndex: isActive ? 50 : undefined,
-          }}
-          onMouseEnter={() => device === "desktop" && setHoveredImageId(id)}
-          onMouseLeave={() => device === "desktop" && setHoveredImageId(null)}
-          onClick={() => device !== "desktop" && setActiveImageId(id)}
-        >
-          {createElement("img", {
-            ...props,
-            src: imageSrc,
-            style: {
-              ...fixedStyle,
-              ...(isIcon
-                ? {}
-                : {
-                    ...fixedStyle,
-                    pointerEvents: "auto",
-                  }),
-              display: "block",
-            },
-          })}
-
-          {!isLogo && !isIcon && (
-            <button
-              onClick={(event) => {
-                event.stopPropagation();
-
-                if (!uploadingImageId) {
-                  fileInputRefs.current[String(id)]?.click();
-                }
-              }}
-              className="absolute top-2 right-2 z-50 bg-yellow-400 text-black px-3 py-1.5 rounded-md shadow-md text-xs font-semibold"
-            >
-              {uploadingImageId === id ? "Uploading..." : "Change"}
-            </button>
-          )}
-
-          {(isLogo || isIcon) && isActive && (
-            <div
-              className="absolute inset-0 flex items-center justify-center"
-              style={{
-                backgroundColor: "rgba(0,0,0,0.35)",
-                zIndex: 9999,
-              }}
-              onClick={(event) => {
-                event.stopPropagation();
-
-                if (!uploadingImageId) {
-                  fileInputRefs.current[String(id)]?.click();
-                }
-              }}
-            >
-              {uploadingImageId === id ? (
-                <div className="flex flex-col items-center gap-2 text-white">
-                  <div className="h-6 w-6 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                  <span className="text-sm">Uploading...</span>
-                </div>
-              ) : (
-                <button className="rounded-md bg-yellow-400 px-4 py-2 text-sm font-medium text-black shadow-lg">
-                  Change
-                </button>
-              )}
-            </div>
-          )}
-
-          <input
-            ref={(element) => {
-              fileInputRefs.current[String(id)] = element;
-            }}
-            type="file"
-            accept="image/*"
-            className="hidden"
-            disabled={uploadingImageId === id}
-            onChange={(event) => handleImageChange(event, id, componentKey)}
-          />
-        </div>
-      );
-    }
-
-    if (tag === "svg") {
-      props.style = {
-        ...props.style,
-        flexShrink: 0,
-        display: "block",
-      };
-    }
-
-    const childElements = children
-      ? children.flatMap((child, index) => {
-          const el = renderElement(child, componentKey);
-
-          if (index < children.length - 1) {
-            return [el, " "];
-          }
-
-          return [el];
-        })
-      : content
-        ? [content]
-        : [];
-
-    return createElement(tag, props, ...childElements);
-  };
+    },
+    [
+      canEdit,
+      device,
+      handleImageChange,
+      handleTextSave,
+      isPaused,
+      setIsEditingText,
+      uploadingImageId,
+    ],
+  );
 
   return (
     <>

--- a/src/features/preview/ui/renderer/DefaultElementRenderer.tsx
+++ b/src/features/preview/ui/renderer/DefaultElementRenderer.tsx
@@ -1,0 +1,49 @@
+import { createElement } from "react";
+
+import type { WebElement } from "@/features/preview/types";
+
+import type {
+  ComponentKey,
+  RendererElementProps,
+  RenderElementFn,
+} from "./shared/rendererTypes";
+
+interface DefaultElementRendererProps {
+  element: WebElement;
+  props: RendererElementProps;
+  componentKey?: ComponentKey;
+  renderElement: RenderElementFn;
+}
+
+export function DefaultElementRenderer({
+  element,
+  props,
+  componentKey,
+  renderElement,
+}: DefaultElementRendererProps) {
+  const { tag, content, children } = element;
+
+  if (tag === "svg") {
+    props.style = {
+      ...props.style,
+      flexShrink: 0,
+      display: "block",
+    };
+  }
+
+  const childElements = children
+    ? children.flatMap((child, index) => {
+        const childElement = renderElement(child, componentKey);
+
+        if (index < children.length - 1) {
+          return [childElement, " "];
+        }
+
+        return [childElement];
+      })
+    : content
+      ? [content]
+      : [];
+
+  return createElement(tag, props, ...childElements);
+}

--- a/src/features/preview/ui/renderer/carousel/CarouselElementRenderer.tsx
+++ b/src/features/preview/ui/renderer/carousel/CarouselElementRenderer.tsx
@@ -1,0 +1,38 @@
+import { CarouselRenderer } from "@/features/preview/ui/interactiveComponents/CarouselRenderer";
+import { findCarouselSlides } from "@/features/preview/utils/rendererElements";
+
+import type { ComponentKey, RenderElementFn } from "../shared/rendererTypes";
+import type { WebElement } from "@/features/preview/types";
+
+interface CarouselElementRendererProps {
+  element: WebElement;
+  componentKey?: ComponentKey;
+  isPaused: boolean;
+  renderElement: RenderElementFn;
+}
+
+export function CarouselElementRenderer({
+  element,
+  componentKey,
+  isPaused,
+  renderElement,
+}: CarouselElementRendererProps) {
+  const { id, class: className, children, attributes } = element;
+
+  const autoplay = String(attributes?.["data-autoplay"]) === "true";
+  const intervalAttr = attributes?.["data-interval"];
+  const interval = intervalAttr ? Number(intervalAttr) : undefined;
+  const slides = findCarouselSlides(children);
+
+  return (
+    <CarouselRenderer
+      key={id}
+      className={className}
+      slides={slides}
+      autoplay={autoplay}
+      interval={interval}
+      isPaused={isPaused}
+      renderElement={(child) => renderElement(child, componentKey)}
+    />
+  );
+}

--- a/src/features/preview/ui/renderer/carousel/CarouselSlideRenderer.tsx
+++ b/src/features/preview/ui/renderer/carousel/CarouselSlideRenderer.tsx
@@ -1,0 +1,67 @@
+import { cn } from "@/lib/utils";
+import { useRendererStore } from "@/features/preview/stores/useRendererStore";
+
+import type { BaseRendererProps } from "../shared/rendererTypes";
+
+export function CarouselSlideRenderer({
+  element,
+  componentKey,
+  renderElement,
+  fileInputRefs,
+  onImageChange,
+}: BaseRendererProps) {
+  const { id, class: className, children } = element;
+
+  const activeImageId = useRendererStore((state) => state.activeImageId);
+  const setActiveImageId = useRendererStore((state) => state.setActiveImageId);
+
+  const getCarouselBackgroundImage = () => {
+    return children?.find(
+      (child) =>
+        child.tag === "img" &&
+        child.attributes?.["data-role"] === "carousel-bg",
+    );
+  };
+
+  return (
+    <div key={id} className={cn("w-full h-full", className)}>
+      {children?.map((child) => renderElement(child, componentKey))}
+
+      <button
+        onClick={(event) => {
+          event.stopPropagation();
+
+          const bgImage = getCarouselBackgroundImage();
+
+          if (!bgImage) return;
+
+          if (activeImageId !== bgImage.id) {
+            setActiveImageId(bgImage.id);
+          }
+
+          fileInputRefs.current[String(id)]?.click();
+        }}
+        className="absolute top-4 right-4 z-50 bg-yellow-400 text-black px-4 py-2 rounded-md shadow-lg text-sm font-semibold"
+      >
+        Change
+      </button>
+
+      <input
+        ref={(input) => {
+          fileInputRefs.current[String(id)] = input;
+        }}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={(event) => {
+          const bgImage = getCarouselBackgroundImage();
+
+          if (!bgImage) return;
+
+          onImageChange(event, bgImage.id, componentKey);
+          setActiveImageId(null);
+        }}
+      />
+    </div>
+  );
+}

--- a/src/features/preview/ui/renderer/image/BackgroundImageRenderer.tsx
+++ b/src/features/preview/ui/renderer/image/BackgroundImageRenderer.tsx
@@ -1,0 +1,72 @@
+import { useRendererStore } from "@/features/preview/stores/useRendererStore";
+
+import type {
+  ComponentKey,
+  DeviceType,
+  FileInputRefs,
+  ImageChangeHandler,
+} from "../shared/rendererTypes";
+
+interface BackgroundImageRendererProps {
+  id: number;
+  imageSrc?: string;
+  device: DeviceType;
+  componentKey?: ComponentKey;
+  fileInputRefs: FileInputRefs;
+  uploadingImageId: number | null;
+  onImageChange: ImageChangeHandler;
+}
+
+export function BackgroundImageRenderer({
+  id,
+  imageSrc,
+  device,
+  componentKey,
+  fileInputRefs,
+  uploadingImageId,
+  onImageChange,
+}: BackgroundImageRendererProps) {
+  const setHoveredImageId = useRendererStore(
+    (state) => state.setHoveredImageId,
+  );
+
+  return (
+    <div
+      key={id}
+      className="absolute inset-0"
+      onMouseEnter={() => device === "desktop" && setHoveredImageId(id)}
+      onMouseLeave={() => device === "desktop" && setHoveredImageId(null)}
+    >
+      <img
+        src={imageSrc}
+        className="absolute inset-0 w-full h-full object-cover"
+        style={{ zIndex: 0 }}
+        alt=""
+      />
+
+      <button
+        onClick={(event) => {
+          event.stopPropagation();
+
+          if (!uploadingImageId) {
+            fileInputRefs.current[String(id)]?.click();
+          }
+        }}
+        className="absolute top-2 right-2 z-50 bg-yellow-400 text-black px-3 py-1.5 rounded-md shadow-md text-xs font-semibold"
+      >
+        {uploadingImageId === id ? "Uploading..." : "Change"}
+      </button>
+
+      <input
+        ref={(input) => {
+          fileInputRefs.current[String(id)] = input;
+        }}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        disabled={uploadingImageId === id}
+        onChange={(event) => onImageChange(event, id, componentKey)}
+      />
+    </div>
+  );
+}

--- a/src/features/preview/ui/renderer/image/ImageElementRenderer.tsx
+++ b/src/features/preview/ui/renderer/image/ImageElementRenderer.tsx
@@ -1,0 +1,163 @@
+import { createElement } from "react";
+
+import { useRendererStore } from "@/features/preview/stores/useRendererStore";
+import { cssStringToObject } from "@/features/preview/utils/rendererStyles";
+import type { WebElement } from "@/features/preview/types";
+import { cn } from "@/lib/utils";
+
+import type {
+  ComponentKey,
+  DeviceType,
+  FileInputRefs,
+  ImageChangeHandler,
+  RendererElementProps,
+} from "../shared/rendererTypes";
+import { BackgroundImageRenderer } from "./BackgroundImageRenderer";
+import {
+  isAvatarImage,
+  isBackgroundImageElement,
+  resolveImageRole,
+  resolveImageSrc,
+} from "./imageUtils";
+
+interface ImageElementRendererProps {
+  element: WebElement;
+  props: RendererElementProps;
+  device: DeviceType;
+  componentKey?: ComponentKey;
+  fileInputRefs: FileInputRefs;
+  uploadingImageId: number | null;
+  onImageChange: ImageChangeHandler;
+}
+
+export function ImageElementRenderer({
+  element,
+  props,
+  device,
+  componentKey,
+  fileInputRefs,
+  uploadingImageId,
+  onImageChange,
+}: ImageElementRendererProps) {
+  const { id, attributes } = element;
+
+  const hoveredImageId = useRendererStore((state) => state.hoveredImageId);
+  const activeImageId = useRendererStore((state) => state.activeImageId);
+  const setHoveredImageId = useRendererStore(
+    (state) => state.setHoveredImageId,
+  );
+  const setActiveImageId = useRendererStore((state) => state.setActiveImageId);
+
+  const imageSrc = resolveImageSrc(element);
+  const fixedStyle = cssStringToObject(attributes?.style);
+
+  const role = resolveImageRole(element);
+  const isLogo = role === "logo";
+  const isIcon = role === "social-icon";
+  const isAvatar = isAvatarImage(element);
+
+  const isActive =
+    device === "desktop" ? hoveredImageId === id : activeImageId === id;
+
+  if (isBackgroundImageElement(element)) {
+    return (
+      <BackgroundImageRenderer
+        id={id}
+        imageSrc={imageSrc}
+        device={device}
+        componentKey={componentKey}
+        fileInputRefs={fileInputRefs}
+        uploadingImageId={uploadingImageId}
+        onImageChange={onImageChange}
+      />
+    );
+  }
+
+  return (
+    <div
+      key={id}
+      data-tour={isLogo ? "site-logo" : undefined}
+      className={cn(
+        "relative leading-none",
+        isIcon ? "inline-block" : "block",
+        isIcon || isAvatar ? null : "w-full",
+        isLogo ? "h-full" : "h-auto",
+      )}
+      style={{
+        zIndex: isActive ? 50 : undefined,
+      }}
+      onMouseEnter={() => device === "desktop" && setHoveredImageId(id)}
+      onMouseLeave={() => device === "desktop" && setHoveredImageId(null)}
+      onClick={() => device !== "desktop" && setActiveImageId(id)}
+    >
+      {createElement("img", {
+        ...props,
+        src: imageSrc,
+        style: {
+          ...fixedStyle,
+          ...(isIcon
+            ? {}
+            : {
+                ...fixedStyle,
+                pointerEvents: "auto",
+              }),
+          display: "block",
+        },
+      })}
+
+      {!isLogo && !isIcon && (
+        <button
+          onClick={(event) => {
+            event.stopPropagation();
+
+            if (!uploadingImageId) {
+              fileInputRefs.current[String(id)]?.click();
+            }
+          }}
+          className="absolute top-2 right-2 z-50 bg-yellow-400 text-black px-3 py-1.5 rounded-md shadow-md text-xs font-semibold"
+        >
+          {uploadingImageId === id ? "Uploading..." : "Change"}
+        </button>
+      )}
+
+      {(isLogo || isIcon) && isActive && (
+        <div
+          className="absolute inset-0 flex items-center justify-center"
+          style={{
+            backgroundColor: "rgba(0,0,0,0.35)",
+            zIndex: 9999,
+          }}
+          onClick={(event) => {
+            event.stopPropagation();
+
+            if (!uploadingImageId) {
+              fileInputRefs.current[String(id)]?.click();
+            }
+          }}
+        >
+          {uploadingImageId === id ? (
+            <div className="flex flex-col items-center gap-2 text-white">
+              <div className="h-6 w-6 animate-spin rounded-full border-2 border-white border-t-transparent" />
+              <span className="text-sm">Uploading...</span>
+            </div>
+          ) : (
+            <button className="rounded-md bg-yellow-400 px-4 py-2 text-sm font-medium text-black shadow-lg">
+              Change
+            </button>
+          )}
+        </div>
+      )}
+
+      <input
+        ref={(input) => {
+          fileInputRefs.current[String(id)] = input;
+        }}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        disabled={uploadingImageId === id}
+        onChange={(event) => onImageChange(event, id, componentKey)}
+      />
+    </div>
+  );
+}

--- a/src/features/preview/ui/renderer/image/imageUtils.ts
+++ b/src/features/preview/ui/renderer/image/imageUtils.ts
@@ -1,0 +1,55 @@
+import type { WebElement } from "@/features/preview/types";
+
+export function resolveImageSrc(element: WebElement) {
+  const { content, attributes } = element;
+
+  if (typeof content === "string" && content.startsWith("http")) {
+    return content;
+  }
+
+  return attributes?.src as string | undefined;
+}
+
+export function isBackgroundImageElement(element: WebElement) {
+  const role = element.attributes?.["data-role"];
+
+  return role === "carousel-bg" || role === "overlay-bg";
+}
+
+export function resolveImageRole(element: WebElement) {
+  const explicitRole = element.attributes?.["data-role"];
+
+  if (typeof explicitRole === "string") {
+    return explicitRole;
+  }
+
+  const className = element.class;
+
+  if (
+    className?.includes("h-[") ||
+    className?.includes("h-full") ||
+    className?.includes("object-cover") ||
+    className?.includes("absolute")
+  ) {
+    return "cover";
+  }
+
+  return "contain";
+}
+
+export function isAvatarImage(element: WebElement) {
+  const className = element.class;
+
+  return Boolean(
+    className?.includes("rounded-full") && className?.match(/\bw-\d+/),
+  );
+}
+
+export function findBackgroundImage(
+  children: WebElement[] | undefined,
+  role: "carousel-bg" | "overlay-bg",
+) {
+  return children?.find(
+    (child) => child.tag === "img" && child.attributes?.["data-role"] === role,
+  );
+}

--- a/src/features/preview/ui/renderer/sections/HeroSectionRenderer.tsx
+++ b/src/features/preview/ui/renderer/sections/HeroSectionRenderer.tsx
@@ -1,0 +1,68 @@
+import { cn } from "@/lib/utils";
+
+import type { BaseRendererProps } from "../shared/rendererTypes";
+import { findBackgroundImage } from "../image/imageUtils";
+
+export function HeroSectionRenderer({
+  element,
+  componentKey,
+  renderElement,
+  fileInputRefs,
+  uploadingImageId,
+  onImageChange,
+}: BaseRendererProps) {
+  const { id, class: className, children } = element;
+
+  const bgImage = findBackgroundImage(children, "carousel-bg");
+  const isUploading = bgImage && uploadingImageId === bgImage.id;
+
+  return (
+    <section key={id} className={cn("relative", className)}>
+      {bgImage && renderElement(bgImage, componentKey)}
+
+      {isUploading && (
+        <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/40 text-white">
+          <div className="flex flex-col items-center gap-2">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-white border-t-transparent" />
+            <span className="text-sm">Uploading...</span>
+          </div>
+        </div>
+      )}
+
+      <>
+        {children
+          ?.filter((child) => child !== bgImage)
+          .map((child) => renderElement(child, componentKey))}
+      </>
+
+      <button
+        data-tour="hero-background"
+        onClick={(event) => {
+          event.stopPropagation();
+
+          if (!isUploading) {
+            fileInputRefs.current[`hero-${id}`]?.click();
+          }
+        }}
+        className="absolute top-2 right-2 z-50 bg-yellow-400 text-black px-3 py-1.5 rounded-md shadow-md text-xs font-semibold"
+      >
+        {isUploading ? "Uploading..." : "Change Background"}
+      </button>
+
+      <input
+        ref={(input) => {
+          fileInputRefs.current[`hero-${id}`] = input;
+        }}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        disabled={Boolean(isUploading)}
+        onChange={(event) => {
+          if (bgImage) {
+            onImageChange(event, bgImage.id, componentKey);
+          }
+        }}
+      />
+    </section>
+  );
+}

--- a/src/features/preview/ui/renderer/sections/OverlaySectionRenderer.tsx
+++ b/src/features/preview/ui/renderer/sections/OverlaySectionRenderer.tsx
@@ -1,0 +1,69 @@
+import { cn } from "@/lib/utils";
+
+import type { BaseRendererProps } from "../shared/rendererTypes";
+import { findBackgroundImage } from "../image/imageUtils";
+
+export function OverlaySectionRenderer({
+  element,
+  componentKey,
+  renderElement,
+  fileInputRefs,
+  uploadingImageId,
+  onImageChange,
+}: BaseRendererProps) {
+  const { id, class: className, children } = element;
+
+  const bgImage = findBackgroundImage(children, "overlay-bg");
+  const isUploading = bgImage && uploadingImageId === bgImage.id;
+
+  return (
+    <section key={id} className={cn("relative", className)}>
+      {bgImage && renderElement(bgImage, componentKey)}
+
+      {isUploading && (
+        <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/40 text-white">
+          <div className="flex flex-col items-center gap-2">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-white border-t-transparent" />
+            <span className="text-sm">Uploading...</span>
+          </div>
+        </div>
+      )}
+
+      <>
+        {children
+          ?.filter((child) => child !== bgImage)
+          .map((child) => renderElement(child, componentKey))}
+      </>
+
+      {bgImage && (
+        <>
+          <button
+            onClick={(event) => {
+              event.stopPropagation();
+
+              if (!isUploading) {
+                fileInputRefs.current[`overlay-${id}`]?.click();
+              }
+            }}
+            className="absolute top-2 right-2 z-50 bg-yellow-400 text-black px-3 py-1.5 rounded-md shadow-md text-xs font-semibold"
+          >
+            {isUploading ? "Uploading..." : "Change Background"}
+          </button>
+
+          <input
+            ref={(input) => {
+              fileInputRefs.current[`overlay-${id}`] = input;
+            }}
+            type="file"
+            accept="image/*"
+            className="hidden"
+            disabled={Boolean(isUploading)}
+            onChange={(event) => {
+              onImageChange(event, bgImage.id, componentKey);
+            }}
+          />
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/features/preview/ui/renderer/shared/createElementProps.ts
+++ b/src/features/preview/ui/renderer/shared/createElementProps.ts
@@ -1,0 +1,23 @@
+import { normalizeAttributes } from "@/features/preview/utils/rendererAttributes";
+import { cssStringToObject } from "@/features/preview/utils/rendererStyles";
+import type { WebElement } from "@/features/preview/types";
+import { DeviceType, RendererElementProps } from "./rendererTypes";
+
+interface CreateElementPropsParams {
+  element: WebElement;
+  device: DeviceType;
+}
+
+export function createElementProps({
+  element,
+  device,
+}: CreateElementPropsParams): RendererElementProps {
+  return {
+    key: `${element.id}-${device}`,
+    className: element.class,
+    ...normalizeAttributes(element.attributes),
+    style: {
+      ...cssStringToObject(element.attributes?.style),
+    },
+  };
+}

--- a/src/features/preview/ui/renderer/shared/editableTextProps.ts
+++ b/src/features/preview/ui/renderer/shared/editableTextProps.ts
@@ -1,0 +1,85 @@
+import type React from "react";
+
+import type { WebElement } from "@/features/preview/types";
+import {
+  ComponentKey,
+  RendererElementProps,
+  TextSaveHandler,
+} from "./rendererTypes";
+
+interface ApplyEditableTextPropsParams {
+  props: RendererElementProps;
+  element: WebElement;
+  componentKey?: ComponentKey;
+  canEdit: boolean;
+  onTextSave: TextSaveHandler;
+  setIsEditingText: (isEditing: boolean) => void;
+}
+
+export function applyEditableTextProps({
+  props,
+  element,
+  componentKey,
+  canEdit,
+  onTextSave,
+  setIsEditingText,
+}: ApplyEditableTextPropsParams): RendererElementProps {
+  const { id, tag, content, children } = element;
+
+  const hasNoChildren = !children || children.length === 0;
+
+  const isTextElement =
+    typeof content === "string" && hasNoChildren && tag !== "img";
+
+  const isEditable = isTextElement && canEdit;
+
+  if (!isEditable) {
+    return props;
+  }
+
+  props.contentEditable = true;
+  props.suppressContentEditableWarning = true;
+
+  if (["h1", "h2", "p"].includes(tag)) {
+    (
+      props as unknown as React.HTMLAttributes<HTMLElement> &
+        Record<string, unknown>
+    )["data-tour"] = "editable-text";
+  }
+
+  props.style = {
+    ...(props.style || {}),
+    cursor: "text",
+    transition: "all 0.15s ease",
+  };
+
+  props.onFocus = (event) => {
+    setIsEditingText(true);
+    event.currentTarget.style.outline = "2px solid #facc15";
+  };
+
+  props.onBlur = (event) => {
+    setIsEditingText(false);
+    event.currentTarget.style.outline = "none";
+    onTextSave(id, componentKey, event.currentTarget.innerText);
+  };
+
+  props.onMouseEnter = (event) => {
+    event.currentTarget.style.outline = "2px dashed rgba(250,204,21,0.7)";
+  };
+
+  props.onMouseLeave = (event) => {
+    if (document.activeElement !== event.currentTarget) {
+      event.currentTarget.style.outline = "none";
+    }
+  };
+
+  props.onKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      event.currentTarget.blur();
+    }
+  };
+
+  return props;
+}

--- a/src/features/preview/ui/renderer/shared/rendererElementUtils.ts
+++ b/src/features/preview/ui/renderer/shared/rendererElementUtils.ts
@@ -1,0 +1,42 @@
+import type { WebElement } from "@/features/preview/types";
+
+import type { DeviceType } from "@/features/preview/ui/renderer/shared/rendererTypes";
+
+export type RendererKind =
+  | "carousel"
+  | "carousel-slide"
+  | "overlay-section"
+  | "hero-section"
+  | "image"
+  | "default";
+
+export function getElementKey(element: WebElement, device: DeviceType) {
+  return `${element.id}-${device}`;
+}
+
+export function getElementKind(element: WebElement): RendererKind {
+  const componentType = element.attributes?.["data-component"];
+  const elementRole = element.attributes?.["data-role"];
+
+  if (componentType === "carousel") {
+    return "carousel";
+  }
+
+  if (elementRole === "carousel-slide") {
+    return "carousel-slide";
+  }
+
+  if (componentType === "overlay-section") {
+    return "overlay-section";
+  }
+
+  if (componentType === "hero-section") {
+    return "hero-section";
+  }
+
+  if (element.tag === "img") {
+    return "image";
+  }
+
+  return "default";
+}

--- a/src/features/preview/ui/renderer/shared/rendererTypes.ts
+++ b/src/features/preview/ui/renderer/shared/rendererTypes.ts
@@ -1,0 +1,42 @@
+import type React from "react";
+import type { ReactElement } from "react";
+
+import type { WebElement } from "@/features/preview/types";
+
+export type DeviceType = "desktop" | "tablet" | "mobile";
+
+export type ComponentKey = "navbar" | "footer";
+
+export type FileInputRefs = React.MutableRefObject<
+  Record<string, HTMLInputElement | null>
+>;
+
+export type RenderElementFn = (
+  element: WebElement,
+  componentKey?: ComponentKey,
+) => ReactElement;
+
+export type RendererElementProps = React.AllHTMLAttributes<HTMLElement> & {
+  key: React.Key;
+};
+
+export type ImageChangeHandler = (
+  event: React.ChangeEvent<HTMLInputElement>,
+  id: number,
+  componentKey?: ComponentKey,
+) => void;
+
+export type TextSaveHandler = (
+  id: number,
+  componentKey: ComponentKey | undefined,
+  newContent: string,
+) => void;
+
+export interface BaseRendererProps {
+  element: WebElement;
+  componentKey?: ComponentKey;
+  renderElement: RenderElementFn;
+  fileInputRefs: FileInputRefs;
+  uploadingImageId: number | null;
+  onImageChange: ImageChangeHandler;
+}


### PR DESCRIPTION
## Description

Refactored the preview JSON renderer to make it more modular, readable, and easier to maintain.

## Changes Made

- Split `JsonRenderer` rendering logic into focused renderer components.
- Added separate renderer modules for:
  - Carousel rendering
  - Carousel slide rendering
  - Image rendering
  - Background image rendering
  - Hero section rendering
  - Overlay section rendering
  - Default element rendering
- Moved shared renderer logic into reusable shared files.
- Added Zustand store for renderer UI state such as active image, hovered image, and text editing state.
- Extracted renderer action handlers for text saving and image change handling.
- Added helper utilities for detecting renderer element type and generating element keys.