### PR TITLE
Add section reordering support in preview editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@icons-pack/react-simple-icons": "^13.13.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
@@ -297,6 +306,28 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -4445,6 +4476,31 @@ snapshots:
   '@better-fetch/fetch@1.1.21': {}
 
   '@date-fns/tz@1.4.1': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@emnapi/core@1.9.0':
     dependencies:

--- a/src/features/preview/Preview.tsx
+++ b/src/features/preview/Preview.tsx
@@ -16,7 +16,7 @@ import useUpdateWebsitePage from "@/features/preview/hooks/useUpdateWebsitePage"
 import { usePreviewOnboardingTour } from "@/features/preview/hooks/usePreviewOnboardingTour";
 import { mapApiToWebsiteData } from "@/features/preview/utils/mapApiToWebsiteData";
 import { updateElementRecursive } from "@/features/preview/utils/previewElements";
-
+import useReorderPageSections from "@/features/preview/hooks/useReorderPageSections";
 import { ChatPanelJson } from "./ui/ChatPanelJson";
 import { PreviewPanelJson } from "./ui/PreviewPanelJson";
 
@@ -32,6 +32,7 @@ export default function Preview() {
     },
     metadata: {},
   });
+  const reorderPageSections = useReorderPageSections();
 
   const params = useParams();
   const websiteId = params.websiteId as string;
@@ -57,6 +58,28 @@ export default function Preview() {
     hasSeenTour: generatedWebsite?.is_congrats_modal_shown,
     onFinish: handleFinishOnboardingTour,
   });
+
+  const handleReorderSections = async (
+    pageId: string,
+    reorderedSections: WebElement[],
+  ) => {
+    setWebsiteData((prev) => ({
+      ...prev,
+      elements: prev.elements.map((page) =>
+        page.page_id === pageId
+          ? {
+              ...page,
+              pageContent: reorderedSections,
+            }
+          : page,
+      ),
+    }));
+
+    await reorderPageSections.mutateAsync({
+      pageId,
+      sectionIds: reorderedSections.map((section) => section.id),
+    });
+  };
 
   const handleWebsiteGenerated = useCallback((data: WebsiteData) => {
     setWebsiteData(data);
@@ -173,6 +196,7 @@ export default function Preview() {
           onUpdateElement={handleUpdateElement}
           onUpdateSharedElement={handleUpdateSharedElement}
           onPageChange={setCurrentPageId}
+          onReorderSections={handleReorderSections}
         />
 
         {!isChatOpen && (

--- a/src/features/preview/api/reorderPageSections.ts
+++ b/src/features/preview/api/reorderPageSections.ts
@@ -1,0 +1,39 @@
+export interface ReorderPageSectionsBody {
+  sectionIds: number[];
+}
+
+export const reorderPageSections = async (
+  pageId: string,
+  body: ReorderPageSectionsBody,
+) => {
+  try {
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_BACKEND_URL}/pages/${pageId}/sections/reorder`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error("❌ Backend API Error:", errorText);
+
+      return {
+        success: false,
+        error: `Backend returned ${res.status}: ${errorText}`,
+      };
+    }
+
+    const data = await res.json();
+    return data;
+  } catch (err) {
+    console.error("🔥 Network or parsing error:", err);
+
+    return {
+      success: false,
+      error: "Network error or invalid response from server",
+    };
+  }
+};

--- a/src/features/preview/hooks/useReorderPageSections.ts
+++ b/src/features/preview/hooks/useReorderPageSections.ts
@@ -1,0 +1,27 @@
+import { reorderPageSections } from "@/features/preview/api/reorderPageSections";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+const useReorderPageSections = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      pageId,
+      sectionIds,
+    }: {
+      pageId: string;
+      sectionIds: number[];
+    }) =>
+      reorderPageSections(pageId, {
+        sectionIds,
+      }),
+
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: ["page", variables.pageId],
+      });
+    },
+  });
+};
+
+export default useReorderPageSections;

--- a/src/features/preview/types/previewPanel.ts
+++ b/src/features/preview/types/previewPanel.ts
@@ -20,4 +20,5 @@ export interface PreviewPanelJsonProps {
   ) => void;
   onPageChange: (pageId: string) => void;
   currentPageId: string;
+  onReorderSections: (pageId: string, reorderedSections: WebElement[]) => void;
 }

--- a/src/features/preview/ui/JsonRenderer.tsx
+++ b/src/features/preview/ui/JsonRenderer.tsx
@@ -25,6 +25,14 @@ import type {
 import { ImageElementRenderer } from "@/features/preview/ui/renderer/image/ImageElementRenderer";
 import { HeroSectionRenderer } from "@/features/preview/ui/renderer/sections/HeroSectionRenderer";
 import { OverlaySectionRenderer } from "@/features/preview/ui/renderer/sections/OverlaySectionRenderer";
+import { ArrowDown, ArrowUp, GripVertical } from "lucide-react";
+import { closestCenter, DndContext, type DragEndEvent } from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 
 interface JsonRendererProps {
   elements: WebElement[];
@@ -33,11 +41,38 @@ interface JsonRendererProps {
   onUpdateElement?: (id: number, updates: Partial<WebElement>) => void;
   contactPhone?: string;
   floatingWhatsappEnabled?: boolean;
+  onReorderSections?: (reorderedSections: WebElement[]) => void;
   onUpdateSharedElement?: (
     componentKey: ComponentKey,
     elementId: number,
     updates: Partial<WebElement>,
   ) => void;
+}
+
+function SortablePreviewSection({
+  element,
+  children,
+  toolbar,
+}: {
+  element: WebElement;
+  device: DeviceType;
+  children: React.ReactNode;
+  toolbar: (dragHandleProps: {
+    attributes: ReturnType<typeof useSortable>["attributes"];
+    listeners: ReturnType<typeof useSortable>["listeners"];
+    isDragging: boolean;
+  }) => React.ReactNode;
+}) {
+  const { attributes, listeners, setNodeRef, isDragging } = useSortable({
+    id: element.id,
+  });
+
+  return (
+    <div ref={setNodeRef} className="group relative">
+      {toolbar({ attributes, listeners, isDragging })}
+      {children}
+    </div>
+  );
 }
 
 export function JsonRenderer({
@@ -48,6 +83,7 @@ export function JsonRenderer({
   contactPhone,
   floatingWhatsappEnabled,
   onUpdateSharedElement,
+  onReorderSections,
 }: JsonRendererProps) {
   const { user } = useSession();
 
@@ -184,14 +220,99 @@ export function JsonRenderer({
     ],
   );
 
+  const handleMoveSection = (index: number, direction: "up" | "down") => {
+    const newIndex = direction === "up" ? index - 1 : index + 1;
+
+    if (newIndex < 0 || newIndex >= elements.length) return;
+
+    const updatedSections = [...elements];
+
+    [updatedSections[index], updatedSections[newIndex]] = [
+      updatedSections[newIndex],
+      updatedSections[index],
+    ];
+
+    onReorderSections?.(updatedSections);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = elements.findIndex((section) => section.id === active.id);
+    const newIndex = elements.findIndex((section) => section.id === over.id);
+
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const reorderedSections = arrayMove(elements, oldIndex, newIndex);
+
+    onReorderSections?.(reorderedSections);
+  };
+
   return (
     <>
       {sharedComponents?.navbar.map((element) =>
         renderElement(element, "navbar"),
       )}
 
-      <div>{elements.map((element) => renderElement(element))}</div>
+      <DndContext collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext
+          items={elements.map((element) => element.id)}
+          strategy={verticalListSortingStrategy}
+        >
+          <div>
+            {elements.map((element, index) => (
+              <SortablePreviewSection
+                key={getElementKey(element, device)}
+                element={element}
+                device={device}
+                toolbar={({ attributes, listeners, isDragging }) =>
+                  onReorderSections && (
+                    <div className="absolute right-4 top-16 z-50 hidden items-center gap-1 rounded-full border border-white/20 bg-black/60 px-2 py-1 shadow-lg backdrop-blur-md group-hover:flex">
+                      <button
+                        type="button"
+                        {...attributes}
+                        {...listeners}
+                        className={`rounded-full p-1.5 transition ${
+                          isDragging
+                            ? "bg-white text-black"
+                            : "text-white hover:bg-white/20"
+                        }`}
+                        title="Drag section"
+                      >
+                        <GripVertical className="h-4 w-4" />
+                      </button>
 
+                      <button
+                        type="button"
+                        disabled={index === 0}
+                        onClick={() => handleMoveSection(index, "up")}
+                        className="rounded-full p-1.5 text-white transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-30"
+                        title="Move section up"
+                      >
+                        <ArrowUp className="h-4 w-4" />
+                      </button>
+
+                      <button
+                        type="button"
+                        disabled={index === elements.length - 1}
+                        onClick={() => handleMoveSection(index, "down")}
+                        className="rounded-full p-1.5 text-white transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-30"
+                        title="Move section down"
+                      >
+                        <ArrowDown className="h-4 w-4" />
+                      </button>
+                    </div>
+                  )
+                }
+              >
+                {renderElement(element)}
+              </SortablePreviewSection>
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
       {sharedComponents?.footer.map((element) =>
         renderElement(element, "footer"),
       )}

--- a/src/features/preview/ui/PreviewPanelJson.tsx
+++ b/src/features/preview/ui/PreviewPanelJson.tsx
@@ -30,6 +30,7 @@ export function PreviewPanelJson({
   onUpdateElement,
   onUpdateSharedElement,
   onPageChange,
+  onReorderSections,
   currentPageId,
 }: PreviewPanelJsonProps) {
   const [device, setDevice] = useState<DeviceType>("desktop");
@@ -204,6 +205,7 @@ export function PreviewPanelJson({
         floatingWhatsappEnabled={freshData?.floating_whatsapp_enabled}
         onUpdateElement={onUpdateElement}
         onUpdateSharedElement={onUpdateSharedElement}
+        onReorderSections={onReorderSections}
       />
     </div>
   );

--- a/src/features/preview/ui/previewPanel/PreviewFrame.tsx
+++ b/src/features/preview/ui/previewPanel/PreviewFrame.tsx
@@ -33,6 +33,7 @@ interface PreviewFrameProps {
     elementId: number,
     updates: Partial<WebElement>,
   ) => void;
+  onReorderSections?: (pageId: string, reorderedSections: WebElement[]) => void;
 }
 
 export function PreviewFrame({
@@ -44,6 +45,7 @@ export function PreviewFrame({
   floatingWhatsappEnabled,
   onUpdateElement,
   onUpdateSharedElement,
+  onReorderSections,
 }: PreviewFrameProps) {
   const frameRef = useRef<HTMLIFrameElement | null>(null);
 
@@ -141,6 +143,9 @@ export function PreviewFrame({
                 onUpdateElement?.(currentPageId, elementId, updates)
               }
               onUpdateSharedElement={onUpdateSharedElement}
+              onReorderSections={(reorderedSections) =>
+                onReorderSections?.(currentPageId, reorderedSections)
+              }
               floatingWhatsappEnabled={floatingWhatsappEnabled}
             />
           </Frame>


### PR DESCRIPTION
## Description
This PR adds section reordering support in the preview editor.

### Changes Made
- Added API integration for reordering page sections.
- Added React Query mutation hook for section reorder updates.
- Passed section reorder handlers through preview components.
- Added section move controls in the preview renderer.
- Added drag-and-drop dependency support for section ordering.