### PR TITLE
Open Help Docs links in new tab

### DIFF
--- a/src/features/dashboard/ui/AppSidebar.tsx
+++ b/src/features/dashboard/ui/AppSidebar.tsx
@@ -96,7 +96,7 @@ export function AppSidebar() {
         <SidebarMenu className="gap-2">
           <SidebarMenuItem>
             <SidebarMenuButton asChild>
-              <Link href="/help">
+              <Link href="/help" target="_blank" rel="noopener noreferrer">
                 <CircleHelp />
                 <span>Help Docs</span>
               </Link>

--- a/src/features/preview/ui/previewPanel/PreviewHeader.tsx
+++ b/src/features/preview/ui/previewPanel/PreviewHeader.tsx
@@ -100,7 +100,12 @@ export function PreviewHeader({
         </Button>
 
         <Button variant="outline" asChild>
-          <Link href="/help" className="flex items-center gap-2">
+          <Link
+            href="/help"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-2"
+          >
             <CircleHelp className="h-4 w-4" />
             <span className="hidden sm:inline">Help Docs</span>
             <span className="sm:hidden">Docs</span>

--- a/src/shared/ui/Navbar.tsx
+++ b/src/shared/ui/Navbar.tsx
@@ -54,7 +54,12 @@ export default function Navbar() {
         {user ? (
           <div className="flex items-center gap-3">
             <Button asChild variant="outline" className="rounded-2xl">
-              <Link href="/help" className="flex items-center gap-2">
+              <Link
+                href="/help"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-2"
+              >
                 <CircleHelp className="h-4 w-4" />
                 Help Docs
               </Link>


### PR DESCRIPTION
## Description
This PR updates Help Docs navigation links to open in a new browser tab.

### Changes Made

- Added target="_blank" to Help Docs links
- Added rel="noopener noreferrer" for safer external tab behavior
- Keeps users on their current dashboard/preview page while viewing docs