### PR TITLE
Fix/support nested page sections

### DIFF
--- a/src/app/(wizard)/layout.tsx
+++ b/src/app/(wizard)/layout.tsx
@@ -7,7 +7,7 @@ export default function WizardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <ProtectedRoute allowedRole="user">
+    <ProtectedRoute allowedRoles={["user"]}>
       <div className="min-h-screen flex flex-col">
         <Navbar />
         <main className="flex-1">{children}</main>

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -11,7 +11,7 @@ export default function AdminLayout({
 }) {
   return (
     /* 1. Wrap everything in the ProtectedRoute with the 'admin' role requirement */
-    <ProtectedRoute allowedRole="admin">
+    <ProtectedRoute allowedRoles={["admin"]}>
       <SidebarProvider>
         <div className="flex min-h-screen w-full">
           <Suspense

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -9,7 +9,7 @@ export default function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <ProtectedRoute allowedRole="user">
+    <ProtectedRoute allowedRoles={["user"]}>
       <div className="pt-16">
         <SidebarProvider defaultOpen={true}>
           <AppSidebar />

--- a/src/app/domain/[websiteId]/page.tsx
+++ b/src/app/domain/[websiteId]/page.tsx
@@ -9,7 +9,7 @@ export default function DomainPage() {
   const { websiteId } = useParams<{ websiteId: string }>();
 
   return (
-    <ProtectedRoute allowedRole="user">
+    <ProtectedRoute allowedRoles={["user"]}>
       <DomainModalWrapper websiteId={websiteId} onClose={() => router.back()} />
     </ProtectedRoute>
   );

--- a/src/app/preview/[websiteId]/page.tsx
+++ b/src/app/preview/[websiteId]/page.tsx
@@ -3,7 +3,7 @@ import { ProtectedRoute } from "@/shared/routes";
 
 export default function Home() {
   return (
-    <ProtectedRoute allowedRole="user">
+    <ProtectedRoute allowedRoles={["user", "admin"]}>
       <Preview />
     </ProtectedRoute>
   );

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,8 +1,8 @@
-"use client"
+"use client";
 
-import * as React from "react"
+import * as React from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Table({ className, ...props }: React.ComponentProps<"table">) {
   return (
@@ -16,7 +16,7 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
         {...props}
       />
     </div>
-  )
+  );
 }
 
 function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
@@ -26,7 +26,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
       className={cn("[&_tr]:border-b", className)}
       {...props}
     />
-  )
+  );
 }
 
 function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
@@ -36,7 +36,7 @@ function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
       className={cn("[&_tr:last-child]:border-0", className)}
       {...props}
     />
-  )
+  );
 }
 
 function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
@@ -45,11 +45,11 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
       data-slot="table-footer"
       className={cn(
         "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
@@ -58,11 +58,11 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
       data-slot="table-row"
       className={cn(
         "hover:bg-muted/50 data-[state=selected]:bg-muted border-b transition-colors",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TableHead({ className, ...props }: React.ComponentProps<"th">) {
@@ -71,11 +71,11 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
       data-slot="table-head"
       className={cn(
         "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TableCell({ className, ...props }: React.ComponentProps<"td">) {
@@ -84,11 +84,11 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
       data-slot="table-cell"
       className={cn(
         "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
-        className
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function TableCaption({
@@ -101,7 +101,7 @@ function TableCaption({
       className={cn("text-muted-foreground mt-4 text-sm", className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -113,4 +113,4 @@ export {
   TableRow,
   TableCell,
   TableCaption,
-}
+};

--- a/src/features/admin/ui/ApprovedWebsitesTable.tsx
+++ b/src/features/admin/ui/ApprovedWebsitesTable.tsx
@@ -30,6 +30,7 @@ import {
   Mail,
   Phone,
   User,
+  Eye,
 } from "lucide-react";
 import { useDebouncedCallback } from "../hooks/useDebounce";
 import { toast } from "sonner";
@@ -121,7 +122,7 @@ export const ApprovedWebsitesTable = ({
                 <TableHead>Contact</TableHead>
                 <TableHead>Website Title</TableHead>
                 <TableHead>Total Price</TableHead>
-                <TableHead className="text-right">Payment</TableHead>
+                <TableHead className="text-right">Action</TableHead>
               </TableRow>
             </TableHeader>
 
@@ -180,14 +181,26 @@ export const ApprovedWebsitesTable = ({
                       </TableCell>
 
                       <TableCell className="text-right">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          onClick={() => setSelectedPayment(site)}
-                          className="h-8 gap-2 hover:bg-blue-50 hover:text-blue-700"
-                        >
-                          View Payment
-                        </Button>
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => router.push(`/preview/${site.id}`)}
+                            className="gap-2"
+                          >
+                            <Eye className="h-4 w-4" />
+                            Preview
+                          </Button>
+
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => setSelectedPayment(site)}
+                            className="h-8 gap-2 hover:bg-blue-50 hover:text-blue-700"
+                          >
+                            View Payment
+                          </Button>
+                        </div>
                       </TableCell>
                     </TableRow>
                   );

--- a/src/features/admin/ui/DraftWebsitesTable.tsx
+++ b/src/features/admin/ui/DraftWebsitesTable.tsx
@@ -27,6 +27,7 @@ import {
   Mail,
   Phone,
   User,
+  Eye,
 } from "lucide-react";
 import { useDebouncedCallback } from "../hooks/useDebounce";
 
@@ -91,6 +92,7 @@ export const DraftWebsitesTable = ({
                 <TableHead>Contact</TableHead>
                 <TableHead>Website Title</TableHead>
                 <TableHead>Created At</TableHead>
+                <TableHead className="text-right">Action</TableHead>
               </TableRow>
             </TableHeader>
 
@@ -98,7 +100,7 @@ export const DraftWebsitesTable = ({
               {websites.length === 0 ? (
                 <TableRow>
                   <TableCell
-                    colSpan={7}
+                    colSpan={6}
                     className="h-24 text-center text-muted-foreground"
                   >
                     No results found.
@@ -129,6 +131,17 @@ export const DraftWebsitesTable = ({
                         {site.createdAt
                           ? new Date(site.createdAt).toLocaleDateString("en-GB")
                           : "-"}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => router.push(`/preview/${site.id}`)}
+                          className="gap-2"
+                        >
+                          <Eye className="h-4 w-4" />
+                          Preview
+                        </Button>
                       </TableCell>
                     </TableRow>
                   );

--- a/src/features/admin/ui/PendingWebsitesTable.tsx
+++ b/src/features/admin/ui/PendingWebsitesTable.tsx
@@ -30,6 +30,7 @@ import {
   Mail,
   Phone,
   User,
+  Eye,
 } from "lucide-react";
 import { useApprovePayment } from "@/features/admin/hooks/useApprovePayment";
 import { useDebouncedCallback } from "../hooks/useDebounce";
@@ -193,25 +194,37 @@ export const PendingWebsitesTable = ({
                         </Badge>
                       </TableCell>
                       <TableCell className="text-right">
-                        <Button
-                          size="sm"
-                          className="bg-green-600 hover:bg-green-700 text-white"
-                          onClick={() => {
-                            setCurrentSite(site);
-                            setPaymentData({
-                              websiteId: site.id,
-                              totalAmount: total,
-                              paymentType: "full",
-                              paidAmount: roundDown(site.domainPrice),
-                              paymentDate: new Date()
-                                .toISOString()
-                                .split("T")[0],
-                            });
-                            setPaymentModalOpen(true);
-                          }}
-                        >
-                          Approve
-                        </Button>
+                        <div className="flex justify-end gap-2">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => router.push(`/preview/${site.id}`)}
+                            className="gap-2"
+                          >
+                            <Eye className="h-4 w-4" />
+                            Preview
+                          </Button>
+
+                          <Button
+                            size="sm"
+                            className="bg-green-600 hover:bg-green-700 text-white"
+                            onClick={() => {
+                              setCurrentSite(site);
+                              setPaymentData({
+                                websiteId: site.id,
+                                totalAmount: total,
+                                paymentType: "full",
+                                paidAmount: roundDown(site.domainPrice),
+                                paymentDate: new Date()
+                                  .toISOString()
+                                  .split("T")[0],
+                              });
+                              setPaymentModalOpen(true);
+                            }}
+                          >
+                            Approve
+                          </Button>
+                        </div>
                       </TableCell>
                     </TableRow>
                   );

--- a/src/features/preview/Preview.tsx
+++ b/src/features/preview/Preview.tsx
@@ -22,6 +22,7 @@ import { PreviewPanelJson } from "./ui/PreviewPanelJson";
 import { WebsiteSetupModal } from "../website-templates/ui/WebsiteSetupModal";
 import useDeletePageSection from "./hooks/useDeletePageSection";
 import { DeleteSectionDialog } from "./ui/previewPanel/DeleteSectionDialog";
+import { useSession } from "@/shared/session/useSession";
 
 export default function Preview() {
   const [isChatOpen, setIsChatOpen] = useState(false);
@@ -56,6 +57,10 @@ export default function Preview() {
   const { data: generatedWebsite } = useGetGeneratedWebsite(websiteId);
 
   const [hasOpenedSetup, setHasOpenedSetup] = useState(false);
+
+  const { user } = useSession();
+
+  const isAdmin = user?.role === "admin";
 
   useEffect(() => {
     if (shouldShowSetup && generatedWebsite && !hasOpenedSetup) {
@@ -297,6 +302,7 @@ export default function Preview() {
           contactPhone={contactPhone}
           websiteId={websiteId}
           websiteData={websiteData}
+          isAdmin={isAdmin}
           currentPageId={currentPageId}
           onUpdateElement={handleUpdateElement}
           onUpdateSharedElement={handleUpdateSharedElement}

--- a/src/features/preview/types/previewPanel.ts
+++ b/src/features/preview/types/previewPanel.ts
@@ -8,6 +8,7 @@ export interface PreviewPanelJsonProps {
   websiteId: string;
   websiteData: WebsiteData;
   contactPhone: string;
+  isAdmin: boolean;
   onUpdateElement?: (
     pageId: string,
     elementId: number,

--- a/src/features/preview/ui/PreviewPanelJson.tsx
+++ b/src/features/preview/ui/PreviewPanelJson.tsx
@@ -22,11 +22,14 @@ import type {
   DeviceType,
   PreviewPanelJsonProps,
 } from "@/features/preview/types/previewPanel";
+import { useCreateTemplateFromWebsite } from "@/features/website-templates/hooks/useCreateTemplateFromWebsite";
+import { CreateTemplateDialog } from "@/features/website-templates/ui/CreateTemplateDialog";
 
 export function PreviewPanelJson({
   websiteId,
   websiteData,
   contactPhone,
+  isAdmin,
   onUpdateElement,
   onUpdateSharedElement,
   onPageChange,
@@ -39,6 +42,9 @@ export function PreviewPanelJson({
   const router = useRouter();
   const didInitPageRef = useRef(false);
 
+  const [createTemplateDialogOpen, setCreateTemplateDialogOpen] =
+    useState(false);
+
   const { data: freshData, isLoading: isFetchingData } =
     useGetGeneratedWebsite(websiteId);
 
@@ -50,6 +56,8 @@ export function PreviewPanelJson({
 
   const deploymentCount = freshData?.deployment_count ?? 0;
   const isDeployed = deploymentCount > 0;
+
+  const createTemplateMutation = useCreateTemplateFromWebsite();
 
   const { sortedPages, mainPages, groupedSubPages } = getGroupedPreviewPages(
     websiteData.elements,
@@ -169,6 +177,25 @@ export function PreviewPanelJson({
     );
   };
 
+  const handleOpenCreateTemplateDialog = () => {
+    setCreateTemplateDialogOpen(true);
+  };
+  const handleCreateTemplate = () => {
+    createTemplateMutation.mutate(
+      {
+        websiteId,
+      },
+      {
+        onSuccess: () => {
+          toast.success("Template created successfully");
+        },
+        onError: (error) => {
+          toast.error(error.message || "Failed to create template");
+        },
+      },
+    );
+  };
+
   const previewWebsiteData = {
     ...websiteData,
     primary_color: freshData?.primary_color ?? websiteData.primary_color,
@@ -182,10 +209,12 @@ export function PreviewPanelJson({
         isFetchingData={isFetchingData}
         isDeployed={isDeployed}
         isGeneratingPreview={isGeneratingPreview}
+        isAdmin={isAdmin}
         onDeviceChange={setDevice}
         onSharePreview={handleSharePreview}
         onRepublish={handleRepublish}
         onPublish={() => router.push(`/domain/${websiteId}`)}
+        onCreateTemplate={handleOpenCreateTemplateDialog}
       />
 
       <PageSelector
@@ -208,6 +237,14 @@ export function PreviewPanelJson({
         onUpdateSharedElement={onUpdateSharedElement}
         onReorderSections={onReorderSections}
         onDeleteSection={onDeleteSection}
+      />
+
+      <CreateTemplateDialog
+        open={createTemplateDialogOpen}
+        onOpenChange={setCreateTemplateDialogOpen}
+        websiteName={freshData?.title ?? "this website"}
+        onConfirm={handleCreateTemplate}
+        loading={createTemplateMutation.isPending}
       />
     </div>
   );

--- a/src/features/preview/ui/previewPanel/PreviewHeader.tsx
+++ b/src/features/preview/ui/previewPanel/PreviewHeader.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import {
   CircleHelp,
+  FilePlus,
   LayoutDashboard,
   Monitor,
   MoveUpRight,
@@ -30,10 +31,12 @@ interface PreviewHeaderProps {
   isFetchingData: boolean;
   isDeployed: boolean;
   isGeneratingPreview: boolean;
+  isAdmin: boolean;
   onDeviceChange: (device: DeviceType) => void;
   onSharePreview: () => void;
   onRepublish: () => void;
   onPublish: () => void;
+  onCreateTemplate: () => void;
 }
 
 export function PreviewHeader({
@@ -41,10 +44,12 @@ export function PreviewHeader({
   isFetchingData,
   isDeployed,
   isGeneratingPreview,
+  isAdmin,
   onDeviceChange,
   onSharePreview,
   onRepublish,
   onPublish,
+  onCreateTemplate,
 }: PreviewHeaderProps) {
   return (
     <div className="flex items-center justify-between border-b bg-card px-4 py-3">
@@ -111,6 +116,20 @@ export function PreviewHeader({
             <span className="sm:hidden">Docs</span>
           </Link>
         </Button>
+
+        {isAdmin && (
+          <Button
+            variant="outline"
+            onClick={onCreateTemplate}
+            className="flex items-center gap-2"
+          >
+            <FilePlus className="h-4 w-4" />
+
+            <span className="hidden sm:inline">Create Template</span>
+
+            <span className="sm:hidden">Template</span>
+          </Button>
+        )}
 
         <Button variant="outline" asChild>
           <Link href="/dashboard" className="flex items-center gap-2">

--- a/src/features/website-templates/api/createTemplateFromWebsite.ts
+++ b/src/features/website-templates/api/createTemplateFromWebsite.ts
@@ -1,0 +1,27 @@
+export const createTemplateFromWebsite = async ({
+  websiteId,
+}: {
+  websiteId: string;
+}) => {
+  const res = await fetch(
+    `${process.env.NEXT_PUBLIC_BACKEND_URL}/templates/from-website`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
+      body: JSON.stringify({
+        websiteId,
+      }),
+    },
+  );
+
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => null);
+
+    throw new Error(errorData?.message || "Failed to create template");
+  }
+
+  return res.json();
+};

--- a/src/features/website-templates/hooks/useCreateTemplateFromWebsite.ts
+++ b/src/features/website-templates/hooks/useCreateTemplateFromWebsite.ts
@@ -1,0 +1,21 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { createTemplateFromWebsite } from "../api/createTemplateFromWebsite";
+
+export interface CreateTemplateFromWebsiteParams {
+  websiteId: string;
+}
+
+export function useCreateTemplateFromWebsite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: CreateTemplateFromWebsiteParams) =>
+      createTemplateFromWebsite(params),
+
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ["templates"],
+      });
+    },
+  });
+}

--- a/src/features/website-templates/ui/CreateTemplateDialog.tsx
+++ b/src/features/website-templates/ui/CreateTemplateDialog.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  websiteName: string;
+  onConfirm: () => void;
+  loading: boolean;
+}
+
+export function CreateTemplateDialog({
+  open,
+  onOpenChange,
+  websiteName,
+  onConfirm,
+  loading,
+}: Props) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent onClick={(e) => e.stopPropagation()}>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Create template?</AlertDialogTitle>
+
+          <AlertDialogDescription>
+            This will save{" "}
+            <span className="font-medium text-foreground">{websiteName}</span>{" "}
+            as a reusable website template. You can use this template to create
+            new websites later.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+
+          <AlertDialogAction
+            disabled={loading}
+            onClick={() => {
+              onConfirm();
+              onOpenChange(false);
+            }}
+          >
+            {loading ? "Creating..." : "Create Template"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/shared/routes/ProtectedRoute.tsx
+++ b/src/shared/routes/ProtectedRoute.tsx
@@ -4,17 +4,26 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useSession } from "../session";
 
+type UserRole = "admin" | "user";
 interface ProtectedRouteProps {
   children: React.ReactNode;
-  allowedRole?: "admin" | "user";
+  allowedRoles?: UserRole[];
 }
 
 export const ProtectedRoute = ({
   children,
-  allowedRole,
+  allowedRoles,
 }: ProtectedRouteProps) => {
   const { authenticated, loading, user } = useSession();
   const router = useRouter();
+
+  const isUserRole = (role?: string): role is UserRole => {
+    return role === "admin" || role === "user";
+  };
+
+  const hasAccess =
+    !allowedRoles ||
+    (isUserRole(user?.role) && allowedRoles.includes(user.role));
 
   useEffect(() => {
     if (loading) return;
@@ -24,8 +33,10 @@ export const ProtectedRoute = ({
       return;
     }
 
-    if (allowedRole && user?.role !== allowedRole) {
-      console.warn(`Access denied. Expected ${allowedRole}, got ${user?.role}`);
+    if (!hasAccess) {
+      console.warn(
+        `Access denied. Expected ${allowedRoles?.join(", ")}, got ${user?.role}`,
+      );
 
       if (user?.role === "admin") {
         router.replace("/admin/dashboard");
@@ -33,16 +44,12 @@ export const ProtectedRoute = ({
         router.replace("/dashboard");
       }
     }
-  }, [authenticated, loading, user, router, allowedRole]);
+  }, [authenticated, loading, user, router, allowedRoles, hasAccess]);
 
-  if (
-    loading ||
-    !authenticated ||
-    (allowedRole && user?.role !== allowedRole)
-  ) {
+  if (loading || !authenticated || !hasAccess) {
     return (
       <div className="flex items-center justify-center min-h-screen">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
       </div>
     );
   }


### PR DESCRIPTION
## Description

This PR introduces the ability to create reusable website templates directly from existing websites, expands preview access for admins, and improves the admin dashboard with quick preview actions. It also includes a fix for a table hydration issue.

## Changes

### Template Creation

* Add support for creating templates from existing websites
* Add frontend API and React Query hook for template creation
* Add confirmation dialog before creating a template
* Integrate template creation into the preview page

### Admin Access

* Update protected routes to support both `admin` and `user` roles where appropriate
* Allow admins to access website preview pages and related flows

### Admin Dashboard

* Add **Preview** action to:

  * Pending Websites
  * Approved Websites
  * Draft Websites
* Enable admins to open website previews directly from management tables


